### PR TITLE
Convert principals into a list if needed

### DIFF
--- a/pyramid_ipauth/__init__.py
+++ b/pyramid_ipauth/__init__.py
@@ -57,7 +57,10 @@ class IPAuthenticationPolicy(object):
     def __init__(self, ipaddrs, userid=None, principals=None, proxies=None):
         self.ipaddrs = make_ip_set(ipaddrs)
         self.userid = userid
-        self.principals = principals
+        if isinstance(principals, basestring):
+            self.principals = aslist(principals)
+        else:
+            self.principals = principals
         self.proxies = make_ip_set(proxies)
 
     @classmethod


### PR DESCRIPTION
If the module is used together with pyramid_multiauth and a Paste-Deploy configuration file is used to configure the module then the constructor gets the list of principals in form of string from pyramid_multiauth and it needs to be converted into a list.

Without this the principals string will be appended to the list of principals character by character
