### PR TITLE
Python 3 compatibility fix

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -13,5 +13,6 @@ Contributors
 - Marc Rijken <marc@rijken.org>, 2013/08/12
 - Jan Janak <jan@janakj.org>, 2013/09/17
 - Aleksander Sukharev <alexander.sukharev1@gmail.com>, 2016/03/15
+- Scott Searcy <smsearcy@gmail.com>, 2016/09/19
 
 

--- a/pyramid_ipauth/__init__.py
+++ b/pyramid_ipauth/__init__.py
@@ -12,6 +12,7 @@ from pyramid.security import Everyone, Authenticated
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.settings import aslist
 from pyramid.path import DottedNameResolver
+from pyramid.compat import iteritems_
 
 from pyramid_ipauth.utils import make_ip_set, check_ip_address, get_ip_address
 
@@ -101,7 +102,7 @@ class IPAuthenticationPolicy(object):
         """Construct an IPAuthenticationPolicy from deployment settings."""
         # Grab out all the settings keys that start with our prefix.
         ipauth_settings = {}
-        for name, value in settings.iteritems():
+        for name, value in iteritems_(settings):
             if not name.startswith(prefix):
                 continue
             ipauth_settings[name[len(prefix):]] = value

--- a/pyramid_ipauth/__init__.py
+++ b/pyramid_ipauth/__init__.py
@@ -12,7 +12,7 @@ from pyramid.security import Everyone, Authenticated
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.settings import aslist
 from pyramid.path import DottedNameResolver
-from pyramid.compat import iteritems_
+from pyramid.compat import iteritems_, string_types
 
 from pyramid_ipauth.utils import make_ip_set, check_ip_address, get_ip_address
 
@@ -23,12 +23,6 @@ __ver_patch__ = 0
 __ver_sub__ = ""
 __ver_tuple__ = (__ver_major__, __ver_minor__, __ver_patch__, __ver_sub__)
 __version__ = "%d.%d.%d%s" % __ver_tuple__
-
-
-if sys.version_info < (3,):
-    string_types = (basestring,)
-else:
-    string_types = (str,)
 
 
 @implementer(IAuthenticationPolicy)

--- a/pyramid_ipauth/utils.py
+++ b/pyramid_ipauth/utils.py
@@ -13,16 +13,11 @@ import sys
 
 from netaddr import IPAddress, IPNetwork, IPGlob, IPRange, IPSet
 
+from pyramid.compat import integer_types, string_types
+
 #  This is used to split a string on an optional comma,
 #  followed by any amount of whitespace.
 _COMMA_OR_WHITESPACE = re.compile(r",?\s*")
-
-if sys.version_info < (3,):
-    integer_types = (int, long,)
-    string_types = (basestring,)
-else:
-    integer_types = (int,)
-    string_types = (str,)
 
 
 def get_ip_address(request, proxies=None):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
-requires = ['pyramid', 'netaddr', 'unittest2']
+requires = ['pyramid>=1.3.0', 'netaddr', 'unittest2']
 
 setup(name='pyramid_ipauth',
       version='0.3.0',


### PR DESCRIPTION
Fixed error in `IPAuthenticationPolicy.from_settings()` on Python 3 due to `settings.iteritems()` call.

I used `pyramid.compat.iteritems_`, which is available from Pyramid 1.3 onward (and replaced some other version checks with functionality from that library).

I noticed that other plugins (i.e. pyramid_mako) use `pyramid.compat` without specifying a version dependency for Pyramid but I added the requirement to `setup.py` to be more explicit.  Do you have a preference?