### PR TITLE
Warning cleanup and test improvements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+branch = True
+omit = pyramid_ipauth/tests.py
+
+[report]
+show_missing = True
+
+[html]
+directory = coverage_html_report

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 .hg*
 *.pyc
+*.egg
 *.egg-info
+.eggs/
 *.swp
-\.coverage
+.coverage
+.coverage.*
+.tox/
 *~
 dist
 build
 htmlcov
+venv/

--- a/pyramid_ipauth/__init__.py
+++ b/pyramid_ipauth/__init__.py
@@ -4,7 +4,6 @@
 """
 IP-based authentication policy for pyramid.
 """
-import sys
 from zope.interface import implementer
 
 from pyramid.interfaces import IAuthenticationPolicy

--- a/pyramid_ipauth/utils.py
+++ b/pyramid_ipauth/utils.py
@@ -9,7 +9,6 @@ Utility functions for pyramid_ipauth
 
 import re
 import socket
-import sys
 
 from netaddr import IPAddress, IPNetwork, IPGlob, IPRange, IPSet
 

--- a/pyramid_ipauth/utils.py
+++ b/pyramid_ipauth/utils.py
@@ -17,7 +17,7 @@ from pyramid.compat import integer_types, string_types
 
 #  This is used to split a string on an optional comma,
 #  followed by any amount of whitespace.
-_COMMA_OR_WHITESPACE = re.compile(r",?\s*")
+_COMMA_OR_WHITESPACE = re.compile(r"(,\s*|\s+)")
 
 
 def get_ip_address(request, proxies=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[flake8]
+exclude = pyramid_ipauth/tests.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = coverage-clean, py{27,34,35}, flake8, coverage-report
+
+[testenv]
+deps =
+    coverage
+    unittest2
+commands = coverage run --parallel -m unittest discover {posargs}
+
+[testenv:flake8]
+skip_install = true
+deps = flake8
+commands = flake8 pyramid_ipauth
+
+[testenv:coverage-clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:coverage-report]
+deps = coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report


### PR DESCRIPTION
After #5 I noticed that there was a Python 3.5 FutureWarning regarding `re.split()` and warnings about `assertEquals()` so I fixed those and added a `tox.ini` file to simplify running the different tests I was doing (along with coverage and flake8).

Please let me know if there are any changes you would like made.